### PR TITLE
Migrate js_pdp8_app.html from RawGit to jsDelivr

### DIFF
--- a/src/static/html/js_pdp8_app.html
+++ b/src/static/html/js_pdp8_app.html
@@ -10,7 +10,7 @@
 <link rel="stylesheet" href="/js/jspdp8/codemirror/mdn-like.css">
 
 <!-- My Style -->
-<link rel="stylesheet" href="https://rawgit.com/MircoT/js-pdp8/master/app/css/style.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MircoT/js-pdp8@master/app/css/style.css">
 
 <div class="container-fluid">
     <div class="row">
@@ -150,8 +150,8 @@
 
 <!-- CodeMirror -->
 <script src="/js/jspdp8/codemirror/codemirror.js"></script>
-<script src="https://rawgit.com/MircoT/js-pdp8/master/app/js/pdp8_lang.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/MircoT/js-pdp8@master/app/js/pdp8_lang.js"></script>
 
 <!-- Main App -->
-<script src="https://rawgit.com/MircoT/js-pdp8/master/lib/pdp8-compiled.min.js"></script>
-<script src="https://rawgit.com/MircoT/js-pdp8/master/app/js/app-compiled.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/MircoT/js-pdp8@master/lib/pdp8-compiled.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/MircoT/js-pdp8@master/app/js/app-compiled.min.js"></script>


### PR DESCRIPTION
RawGit has been discontinued and is no longer functional. The URLs using RawGit have been updated to use jsDelivr to restore app functionality.